### PR TITLE
CVE-2019-10906, CVE-2016-10745

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click==6.6
 Flask==0.11.1
 itsdangerous==0.24
-Jinja2==2.8
+Jinja2==2.10.1
 MarkupSafe==0.23
 peewee==2.8.3
 Werkzeug==0.11.10


### PR DESCRIPTION
CVE-2019-10906 - high severity
Vulnerable versions: < 2.10.1
Patched version: 2.10.1
In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.
---
CVE-2016-10745 - high severity
Vulnerable versions: < 2.8.1
Patched version: 2.8.1
In Pallets Jinja before 2.8.1, str.format allows a sandbox escape.